### PR TITLE
Keep old versions of pgvector available for migration scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,18 @@ RUN apk add --no-cache \
 
 ARG PGVECTOR_VERSION
 
+# We need to keep old versions of pgvector available for migration scripts
+RUN for version in 0.5.0; do \
+    cd /tmp \
+    && git clone --branch v${version} https://github.com/pgvector/pgvector.git \
+    && cd pgvector \
+    && make \
+    && make install \
+    && cd /tmp \
+    && rm -rf /tmp/pgvector; \
+    done
+
+# Install the specified version
 RUN cd /tmp \
     && git clone --branch v${PGVECTOR_VERSION} https://github.com/pgvector/pgvector.git \
     && cd pgvector \


### PR DESCRIPTION
Our migration scripts specify the pgvector version when upgrading which means we need to keep those versions around for the migrations to work on a fresh database.
