### PR TITLE
Reapply "Add a Postgres config file copied from `cimg/postgres`"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,6 @@ RUN cd /tmp \
     && make install \
     && cd /tmp \
     && rm -rf /tmp/pgvector
+
+COPY postgresql.conf /etc/postgresql/postgresql.conf
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/postgresql.conf
+++ b/postgresql.conf
@@ -1,0 +1,7 @@
+# Copied from cimg-postgres
+shared_buffers = 512MB
+max_connections = 200
+max_prepared_transactions = 200
+max_locks_per_transaction = 512
+max_pred_locks_per_transaction = 256
+listen_addresses = '*'


### PR DESCRIPTION
This reverts commit 870d067e4b72a7f94ef5c0d371c62c77fd960a87.

Some reading: https://www.postgresql.org/message-id/2438977.1697481141%40sss.pgh.pa.us

Tested at https://app.circleci.com/pipelines/github/Zapgram/pilot/138687/workflows/4c586bf6-83f9-4b3a-932e-5ca5bf0d592f